### PR TITLE
Adding travis integration fmt, lint and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      go: 1.13.x
+    - os: osx
+      go: 1.13.x
+  fast_finish: true
+
+script:
+  - make build
+env:
+  global:
+    - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-build:
-	mkdir -p bin
-	GO111MODULE=on go build -o ./bin/gopom ./cmd/gopom
+build: fmt lint test
+	mkdir -p bin && GO111MODULE=on go build -o ./bin/gopom ./cmd/gopom
 
 run: build
 	./bin/gopom "$(command)"
+
+test:
+	GO111MODULE=on go test ./...
+
+fmt:
+	GO111MODULE=on go fmt ./...
+
+lint:
+	GO111MODULE=on golint ./...


### PR DESCRIPTION
### adds travis integration basic one
Try to run `make build` for golang `1.13.x` on `linux` and `osx`.

### adds lint, test, fmt
This should be enough for now when building the app. We might have to rethink if we really need `golint` as `fmt` already fixes `issues` automatically.