### PR TITLE
fixed crash when the task name is not provided in "gopom start"

### DIFF
--- a/internal/app/gopom/commands/start.go
+++ b/internal/app/gopom/commands/start.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/pomodoro"
 	"github.com/spf13/cobra"
 )
@@ -10,10 +11,20 @@ func init() {
 }
 
 var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start task",
+	Use:   "start [taskName]",
+	Short: "Start a task",
 	Run: func(cmd *cobra.Command, args []string) {
-		taskName := args[0]
+		taskName := getTaskName(args)
 		pomodoro.NewPomodoro(taskName, 25*60, 5*60, 20*60, 4).Start()
 	},
+}
+
+func getTaskName(args []string) string {
+	var taskName = "task"
+	if len(args) == 0 {
+		fmt.Println("You haven't provided a task name. I will call it just a \"task\" for you.")
+	} else {
+		taskName = args[0]
+	}
+	return taskName
 }


### PR DESCRIPTION
When I started the app with `gopom start` it failed miserably with:

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/commands.glob..func1(0x987b00, 0x9f5310, 0x0, 0x0)
        /home/tbielaszewski/c/prv/GoPomodoro/internal/app/gopom/commands/start.go:16 +0xfd
github.com/spf13/cobra.(*Command).execute(0x987b00, 0x9f5310, 0x0, 0x0, 0x987b00, 0x9f5310)
        /home/tbielaszewski/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x987880, 0xc000000300, 0x200000003, 0xc000000300)
        /home/tbielaszewski/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x30b
github.com/spf13/cobra.(*Command).Execute(...)
        /home/tbielaszewski/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/commands.Execute()
        /home/tbielaszewski/c/prv/GoPomodoro/internal/app/gopom/commands/root.go:27 +0x31
main.main()
        /home/tbielaszewski/c/prv/GoPomodoro/cmd/gopom/main.go:8 +0x25
```

So I fixed that and the default task name is `task`