### PR TITLE
minor fixes based on golangci-lint linter

### DIFF
--- a/cmd/gopom/main.go
+++ b/cmd/gopom/main.go
@@ -11,7 +11,7 @@ func main() {
 
 	//TODO: introduce cleanup funcion/module that would contain all the logic related to `cleanup`
 	go func() {
-		sigchan := make(chan os.Signal)
+		sigchan := make(chan os.Signal, 1)
 		signal.Notify(sigchan, os.Interrupt)
 		<-sigchan
 		slack.EndDnd()

--- a/internal/app/gopom/slack/slack.go
+++ b/internal/app/gopom/slack/slack.go
@@ -31,7 +31,7 @@ func callSlack(urlS string) error {
 	if resp != nil {
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				err = fmt.Errorf("error when closing response body - %s", err)
+				log.Fatalf("error when closing response body - %s", err)
 			}
 		}()
 	}
@@ -66,7 +66,7 @@ func SetDnd(durationMinutes int) {
 func EndDnd() {
 	log.Println("Ending DND on slack.")
 
-	urlS := fmt.Sprintf("https://slack.com/api/dnd.endSnooze")
+	urlS := "https://slack.com/api/dnd.endSnooze"
 
 	err := callSlack(urlS)
 	if err != nil {


### PR DESCRIPTION
- making interrupt chan buffered to 1 signal only
- removing uneccesary Sprintf as we dont add any arguments and there was no format
- defer Body close err was not used - switched to log.Fatal which will terminate process for now