### PR TITLE
tomekbielaszewski partial pomodoro input fix

### DIFF
--- a/cmd/gopom/main.go
+++ b/cmd/gopom/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
 	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/commands"
+	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/pomodoro"
 	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/slack"
 	"os"
 	"os/signal"
@@ -17,6 +20,17 @@ func main() {
 		slack.EndDnd()
 		os.Exit(0)
 	}()
+
+	go func(input chan rune) {
+		for {
+			reader := bufio.NewReader(os.Stdin)
+			r, _, err := reader.ReadRune()
+			if err != nil {
+				fmt.Println("error error ", err)
+			}
+			input <- r
+		}
+	}(pomodoro.StdinChan)
 
 	commands.Execute()
 }

--- a/cmd/gopom/main.go
+++ b/cmd/gopom/main.go
@@ -26,7 +26,7 @@ func main() {
 			reader := bufio.NewReader(os.Stdin)
 			r, _, err := reader.ReadRune()
 			if err != nil {
-				fmt.Println("error error ", err)
+				fmt.Println("error when reading rune from the stdin reader", err)
 			}
 			input <- r
 		}

--- a/internal/app/gopom/commands/start.go
+++ b/internal/app/gopom/commands/start.go
@@ -50,19 +50,19 @@ var startCmd = &cobra.Command{
 		internalFinishVolume := float64(finishVolume)/10 - 8
 
 		taskName := getTaskName(args)
-		workDuration := viper.GetInt("WORK_DURATION_MINUTES")
-		restDuration := viper.GetInt("REST_DURATION_MINUTES")
-		longRestDuration := viper.GetInt("LONG_REST_DURATION_MINUTES")
+		workDurationMinutes := viper.GetInt("WORK_DURATION_MINUTES")
+		restDurationMinutes := viper.GetInt("REST_DURATION_MINUTES")
+		longRestDurationMinutes := viper.GetInt("LONG_REST_DURATION_MINUTES")
 		maxCycles := viper.GetInt("MAX_CYCLES")
 
 		pomodoro.NewPomodoro(&pomodoro.PomodoroSettings{
-			TaskName:          taskName,
-			WorkDuration:      workDuration * 60,
-			RestDuration:      restDuration * 60,
-			LongRestDuration:  longRestDuration * 60,
-			Cycles:            maxCycles,
-			WorkSoundVolume:   internalWorkVolume,
-			FinishSoundVolume: internalFinishVolume,
+			TaskName:                taskName,
+			WorkDurationMinutes:     workDurationMinutes,
+			RestDurationMinutes:     restDurationMinutes,
+			LongRestDurationMinutes: longRestDurationMinutes,
+			Cycles:                  maxCycles,
+			WorkSoundVolume:         internalWorkVolume,
+			FinishSoundVolume:       internalFinishVolume,
 		}).Start()
 	},
 }

--- a/internal/app/gopom/pomodoro/pomodoro.go
+++ b/internal/app/gopom/pomodoro/pomodoro.go
@@ -226,6 +226,6 @@ func fmtTimer(currentMs int64, totalMs int64) string {
 	currentMin := currentMs / 1000 / 60
 	currentSec := currentMs/1000 - (currentMin * 60)
 	totalMin := totalMs / 1000 / 60
-	totalSec := totalMs/1000 - (totalMs * 60)
+	totalSec := totalMs/1000 - (totalMin * 60)
 	return fmt.Sprintf("%02d:%02d / %02d:%02d", currentMin, currentSec, totalMin, totalSec)
 }


### PR DESCRIPTION
I moved the input listener to main for now and this need to be changed. Before that every new Subtask did create it's own listener which resulted in unreliable UX. Already existing listeners had precedence on getting the user input but the currently active subtask did get it's interruption last. Current solution creates only one input listener and exposes read runes on channel.

I've also simplified the progressbar process - it is active from timestamp to timestamp rather than being incremented manually. This allowed implementing the selector for messages on input channel and refreshing the progress bar with any frequency one like.

There is also some renaming to track the time format used.