### PR TITLE
fixed work continue feature

### DIFF
--- a/internal/app/gopom/pomodoro/pomodoro.go
+++ b/internal/app/gopom/pomodoro/pomodoro.go
@@ -1,11 +1,9 @@
 package pomodoro
 
 import (
-	"bufio"
 	"fmt"
 	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/slack"
 	"github.com/spf13/viper"
-	"os"
 	"time"
 
 	"github.com/BartoszCoyote/GoPomodoro/internal/app/gopom/sound"
@@ -211,13 +209,10 @@ func (p *Pomodoro) longRest() string {
 
 func (p *Pomodoro) waitForUser() string {
 	waitForUser := viper.GetBool("ENABLE_WORK_CONTINUE")
-	if !waitForUser {
-		return WORK_RESUMED_EVENT
+	if waitForUser {
+		fmt.Println("Press Enter to continue...")
+		<-StdinChan
 	}
-
-	fmt.Println("Press any button to continue...")
-	inputScanner := bufio.NewScanner(os.Stdin)
-	inputScanner.Scan()
 
 	return WORK_RESUMED_EVENT
 }


### PR DESCRIPTION
Fixes #34 

The issue was related to duplicated input listeners. One waiting for user input in form of `Enter` another one in goroutine listening for the same events. Then when work interruption code checked whether there been any input event it interrupted the work (since it received event from work-continue feature) and activated work continue feature again. And so on and so on.
Reusing same StdinChan for both solves this issue and makes the code more beautiful 💟 