### PR TITLE
Output status in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ If `make` complains about this - install with:
 `sudo apt-get install libasound2-dev`
 
 # Configuration
+By, default config file is loaded from `.GoPomodoro` in your home directory
+You should format your file like this:
+```
+KEY=VALUE
+KEY1=VALUE1
+```
 
-- SLACK_TOKEN - Slack token used in DND functionality
+- SLACK_TOKEN - Slack token used in DND functionality (this has to be user oauth token starting with xoxp)
 - ENABLE_SLACK_DND (true|false) - enable DND functionality
 - ENABLE_WORK_CONTINUE (true|false) - enable waiting for user prompt when moving on to new work session

--- a/README.md
+++ b/README.md
@@ -27,3 +27,19 @@ KEY1=VALUE1
 - SLACK_TOKEN - Slack token used in DND functionality (this has to be user oauth token starting with xoxp)
 - ENABLE_SLACK_DND (true|false) - enable DND functionality
 - ENABLE_WORK_CONTINUE (true|false) - enable waiting for user prompt when moving on to new work session
+ 
+### ENABLE_ECHO_PROGRESS_TO_FILES (true|false)
+This is a special command that if true will start outputing pomodoro stats and progress to files.
+
+Time in format: `00:01 / 25:00` to file
+```
+/tmp/pomodoro-time
+```
+Stats in format:  `{"done":8,"failed":7,"rests":7}` to file
+```
+/tmp/pomodoro-stats
+```
+
+You can then read these form various applications.
+One use-case - polybar to output timer and stats on polybar.
+

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/faiface/beep v1.0.2
 	github.com/looplab/fsm v0.1.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/rakyll/statik v0.1.6
+	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.2
 )

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rakyll/statik v0.1.6 h1:uICcfUXpgqtw2VopbIncslhAmE5hwc4g20TEyEENBNs=
 github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
+github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
+github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/internal/app/gopom/commands/root.go
+++ b/internal/app/gopom/commands/root.go
@@ -76,6 +76,7 @@ func initConfig() {
 	viper.SetDefault("SLACK_TOKEN", "")
 	viper.SetDefault("ENABLE_SLACK_DND", false)
 	viper.SetDefault("ENABLE_WORK_CONTINUE", false)
+	viper.SetDefault("ENABLE_ECHO_PROGRESS_TO_FILES", false)
 	viper.SetDefault("WORK_DURATION_MINUTES", 25)
 	viper.SetDefault("REST_DURATION_MINUTES", 5)
 	viper.SetDefault("LONG_REST_DURATION_MINUTES", 20)

--- a/internal/app/gopom/commands/start.go
+++ b/internal/app/gopom/commands/start.go
@@ -53,6 +53,7 @@ var startCmd = &cobra.Command{
 		workDurationMinutes := viper.GetInt("WORK_DURATION_MINUTES")
 		restDurationMinutes := viper.GetInt("REST_DURATION_MINUTES")
 		longRestDurationMinutes := viper.GetInt("LONG_REST_DURATION_MINUTES")
+		echoTimerStatsToFile := viper.GetBool("ENABLE_ECHO_PROGRESS_TO_FILES")
 		maxCycles := viper.GetInt("MAX_CYCLES")
 
 		pomodoro.NewPomodoro(&pomodoro.PomodoroSettings{
@@ -63,6 +64,8 @@ var startCmd = &cobra.Command{
 			Cycles:                  maxCycles,
 			WorkSoundVolume:         internalWorkVolume,
 			FinishSoundVolume:       internalFinishVolume,
+			StatsToFileEnabled:      echoTimerStatsToFile,
+			TimerToFileEnabled:      echoTimerStatsToFile,
 		}).Start()
 	},
 }

--- a/internal/app/gopom/pomodoro/stats.go
+++ b/internal/app/gopom/pomodoro/stats.go
@@ -11,9 +11,9 @@ import (
 
 type PomodoroStats struct {
 	Enabled          bool
-	DoneValue        int `json:"done"`
-	InterruptedValue int `json:"failed"`
-	RestsValue       int `json:"rests"`
+	Completions      int `json:"completions"`
+	Interruptions    int `json:"interruptions"`
+	Rests            int `json:"rests"`
 }
 
 func (ps *PomodoroStats) read() {
@@ -54,19 +54,19 @@ func (ps *PomodoroStats) save() {
 
 func (ps *PomodoroStats) Done() {
 	ps.read()
-	ps.DoneValue += 1
+	ps.Completions += 1
 	ps.save()
 }
 
 func (ps *PomodoroStats) Interrupted() {
 	ps.read()
-	ps.InterruptedValue += 1
+	ps.Interruptions += 1
 	ps.save()
 }
 
 func (ps *PomodoroStats) Rest() {
 	ps.read()
-	ps.RestsValue += 1
+	ps.Rests += 1
 	ps.save()
 }
 

--- a/internal/app/gopom/pomodoro/stats.go
+++ b/internal/app/gopom/pomodoro/stats.go
@@ -1,0 +1,86 @@
+package pomodoro
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+type PomodoroStats struct {
+	Enabled          bool
+	DoneValue        int `json:"done"`
+	InterruptedValue int `json:"failed"`
+	RestsValue       int `json:"rests"`
+}
+
+func (ps *PomodoroStats) read() {
+	if !ps.Enabled {
+		return
+	}
+	f, err := os.OpenFile("/tmp/pomodoro-stats", os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		log.Fatal("Cannot open stats file")
+	}
+	defer f.Close()
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, f) // Error handling elided for brevity.
+	if err != nil {
+		log.Fatal("Cannot read file")
+	}
+
+	_ = json.Unmarshal(buf.Bytes(), &ps)
+}
+func (ps *PomodoroStats) save() {
+	if !ps.Enabled {
+		return
+	}
+	f, err := os.OpenFile("/tmp/pomodoro-stats", os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		log.Fatal("Cannot open stats file")
+	}
+	defer f.Close()
+
+	data, err := json.Marshal(ps)
+	if err != nil {
+		log.Fatal("Unable to encode json of stats.")
+	}
+
+	truncateWriteToFile(f, string(data))
+}
+
+func (ps *PomodoroStats) Done() {
+	ps.read()
+	ps.DoneValue += 1
+	ps.save()
+}
+
+func (ps *PomodoroStats) Interrupted() {
+	ps.read()
+	ps.InterruptedValue += 1
+	ps.save()
+}
+
+func (ps *PomodoroStats) Rest() {
+	ps.read()
+	ps.RestsValue += 1
+	ps.save()
+}
+
+func truncateWriteToFile(f *os.File, text string) {
+	err := f.Truncate(0)
+	if err != nil {
+		log.Fatal("Unable to truncate file for stats saving.")
+	}
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		log.Fatal("Unable to seek file for stats saving.")
+	}
+	_, err = fmt.Fprintf(f, text)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/app/gopom/slack/slack.go
+++ b/internal/app/gopom/slack/slack.go
@@ -40,6 +40,7 @@ func callSlack(urlS string) error {
 		return fmt.Errorf("error when calling slack endpoint - %s", err)
 	}
 
+	//TODO: if auth is invalid slack is still sending 200 so this wont help at all we need to parse json body which looks like this - {"ok":false,"error":"invalid_auth"}
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
### ENABLE_ECHO_PROGRESS_TO_FILES (true|false)
This is a special command that if true will start outputing pomodoro stats and progress to files.

Time in format: `00:01 / 25:00` to file
```
/tmp/pomodoro-time
```
Stats in format:  `{"done":8,"failed":7,"rests":7}` to file
```
/tmp/pomodoro-stats
```

You can then read these form various applications.
One use-case - polybar to output timer and stats on polybar.
![image](https://user-images.githubusercontent.com/312118/131394164-0e013894-2524-4be3-b1bd-100d94ed9b03.png)
